### PR TITLE
Support old database name ifit exists - Needed for users who update

### DIFF
--- a/print_history.py
+++ b/print_history.py
@@ -14,6 +14,10 @@ def _default_db_path() -> Path:
     if env_path:
         return Path(env_path).expanduser().resolve()
 
+    #Support the old default database if it exists
+    if Path(__file__).resolve().parent / "data" / "3d_printer_logs.db" :
+        return Path(__file__).resolve().parent / "data" / "3d_printer_logs.db"
+
     return Path(__file__).resolve().parent / "data" / DEFAULT_DB_NAME
 
 


### PR DESCRIPTION
If you update to v0.2.0 your print_history tab goes to the default demo.db.

While you can override with OPENSPOOLMAN_PRINT_HISTORY_DB this change was not in the release notes and breaks existing installs.

Check for 3d_printer_logs.db and use it if it exists.