### PR TITLE
Updated LAN Only model download for filament tracking

### DIFF
--- a/filament_usage_tracker.py
+++ b/filament_usage_tracker.py
@@ -435,7 +435,7 @@ class FilamentUsageTracker:
           download3mfFromLocalFilesystem(uri.path, model_file)
         else:
           log(f"[filament-tracker] Downloading model via FTP: {model_url}")
-          download3mfFromFTP(model_url.replace("ftp://", "").replace(".gcode", ""), model_file)
+          download3mfFromFTP(model_url.rpartition('/')[-1], model_file) # Pull just filename to clear out any unexpected paths
         return model_file.name
     except Exception as exc:
       log(f"Failed to fetch model: {exc}")


### PR DESCRIPTION
New to GIT so hope this is right.

I was having issues where the print history or filament tracking was not working on my P2S in LAN Only mode, Read through the logs and stepped through the code to find issues with the model download was trying to grab paths it didn't have access to from the printers internal storage.

Changes:
Corrected LAN Only gcode file download to fix filament tracking.
Added path filtering to filename only to fix cases where there are unexpected paths.
Added retry attempts to prevent race condition where files were not fully saved on the printer before trying to grab them.
If a file still can't be downloaded, list out the files it could find in the cache directory for debugging.

Required printer option: Store sent files on external storage

Tested on P2S with AMS 2 Pro

Maybe related to issues:
https://github.com/drndos/openspoolman/issues/41
https://github.com/drndos/openspoolman/issues/78