### PR TITLE
Solving assignation faults of PETG-CF(GFG98) and ASA-CF(GFB51)

### DIFF
--- a/filament.py
+++ b/filament.py
@@ -95,6 +95,16 @@ def generate_filament_brand_code(filament_type, filament_brand, filament_variant
     filament_brand_code = "GFS99"
     filament_sub_brand = "PVA"
 
+  elif filament_type == "PETG-CF":
+    filament_brand_code = "GFG98"
+    filament_sub_brand = "PETG-CF"
+
+  elif filament_type == "ASA-CF":
+    filament_brand_code = "GFB51"
+    filament_sub_brand = "ASA-CF"
+
+
+
   elif filament_type == "Support":
     if filament_variant == "G":
       filament_brand_code = "GFS01"


### PR DESCRIPTION
Hi guys,

I’m new to this GitHub topic and ran into the following issue:

I had a problem with the material type PETG-CF in Spoolman. It was being managed correctly, but when I assigned a spool to the AMS trays, the color was updated in the AMS. However, the material then appeared as empty in the dropdown menu on the printer and as “?” in the slicer.

There was no “Generic PETG-CF” selected automatically, although it can be chosen manually.

After some investigation, I was able to fix the issue by adding the corresponding filament_brand_code definitions to filament.py on the running conainer.
I manually set “Generic PETG-CF” to investigate the filament_brand_codes and confirmed it via an MQTT browser.

The only changes I made were related to the codes for ASA-CF and PETG-CF.

After that temporary change, i was able to assign PETG-CF via NFC tag and it was succesfully updated on the printer.

How could this be included in a future release?

Thanks!
